### PR TITLE
Fix justify typo

### DIFF
--- a/src/components/LearningDashBoard/index.tsx
+++ b/src/components/LearningDashBoard/index.tsx
@@ -13,7 +13,7 @@ export default function LearningDashBoard({ initialVocs }: LearningDashBoardProp
   const progress = totalVocs > 0 ? (masteredVocs / totalVocs) * 100 : 0;
   return (
     <div className=" py-5 px-4 w-full mx-auto flex justify-between items-center">
-     <div className="flex justfy-center items-center">
+     <div className="flex justify-center items-center">
      <ProgressCircle percent={progress} />
      <p className="text-xs md:text-md">{masteredVocs} mastered vocabularies.</p>
      </div>


### PR DESCRIPTION
## Summary
- correct `justfy-center` typo in LearningDashBoard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bda9c87a48325a4b5505acbf0bd8d