### PR TITLE
Fix tailwind spacing in VocItem

### DIFF
--- a/src/components/VocItem/index.tsx
+++ b/src/components/VocItem/index.tsx
@@ -7,7 +7,7 @@ export default function VocItem({item, handleClick}: VocItemProps) {
   return (
   <div onClick={handleClick} className="flex items-center justify-between py-5 w-full border-b border-primary-hover gap-2 px-3 hover:bg-primary-hover cursor-pointer">
     
-    <div className="flex items-center justify-start py-5gap-2">
+    <div className="flex items-center justify-start py-5 gap-2">
 
     <p className="font-bold"><span className="text-xl font-bold">{item.word}</span></p>
       </div>


### PR DESCRIPTION
## Summary
- fix spacing typo in `VocItem`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bdcd4bd748325ad8860e4ce531e28